### PR TITLE
feat: reconcile auth project info in rollout workflows

### DIFF
--- a/.github/actions/reconcile-project-info/action.yml
+++ b/.github/actions/reconcile-project-info/action.yml
@@ -1,0 +1,58 @@
+name: Reconcile Project Info
+description: >
+  Reads deployed project metadata from Pulumi outputs, resolves the current AWS
+  account id, and upserts the authservice-compatible project info record into
+  DynamoDB. Must run after pulumi up and before output capture.
+
+inputs:
+  stack:
+    description: Pulumi stack name
+    required: true
+  aws-region:
+    description: AWS region where the DynamoDB table lives
+    required: true
+  working-directory:
+    description: Pulumi project directory (blueprint-relative)
+    required: false
+    default: infra
+
+runs:
+  using: composite
+  steps:
+    - name: Reconcile project info
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        set -euo pipefail
+
+        project_id="$(pulumi stack output projectId --stack "${{ inputs.stack }}" 2>/dev/null || true)"
+        api_id="$(pulumi stack output apiId --stack "${{ inputs.stack }}" 2>/dev/null || true)"
+        api_base_url="$(pulumi stack output apiBaseUrl --stack "${{ inputs.stack }}" 2>/dev/null || true)"
+        table_name="$(pulumi stack output tableName --stack "${{ inputs.stack }}" 2>/dev/null || true)"
+
+        if [[ -z "${project_id}" || -z "${api_id}" || -z "${api_base_url}" || -z "${table_name}" ]]; then
+          echo "failed to resolve project info outputs for stack ${{ inputs.stack }}" >&2
+          exit 1
+        fi
+
+        if ! account_id="$(aws sts get-caller-identity --query Account --output text)"; then
+          echo "failed to resolve AWS account id for stack ${{ inputs.stack }}" >&2
+          exit 1
+        fi
+
+        if [[ -z "${account_id}" || "${account_id}" == "None" || "${account_id}" == "null" ]]; then
+          echo "AWS account id was empty for stack ${{ inputs.stack }}" >&2
+          exit 1
+        fi
+
+        item="$(cat <<EOF
+        {"PK":{"S":"project#${project_id}"},"SK":{"S":"info"},"account_id":{"S":"${account_id}"},"api_id":{"S":"${api_id}"},"api_base_url":{"S":"${api_base_url}"}}
+        EOF
+        )"
+
+        aws dynamodb put-item \
+          --table-name "${table_name}" \
+          --item "${item}" \
+          --region "${{ inputs.aws-region }}"
+
+        echo "project info reconciled for ${project_id}"

--- a/.github/workflows/rollout-hop.yml
+++ b/.github/workflows/rollout-hop.yml
@@ -159,6 +159,12 @@ jobs:
           stack: ${{ inputs.pulumi_stack }}
           aws-region: ${{ inputs.aws_region }}
           working-directory: blueprint/${{ inputs.working_directory }}
+      - name: Reconcile project info
+        uses: ./.ltbase/workflow-repo/.github/actions/reconcile-project-info
+        with:
+          stack: ${{ inputs.pulumi_stack }}
+          aws-region: ${{ inputs.aws_region }}
+          working-directory: blueprint/${{ inputs.working_directory }}
       - name: Capture deployment outputs
         working-directory: blueprint/${{ inputs.working_directory }}
         run: pulumi stack output --json --stack "${{ inputs.pulumi_stack }}" > /tmp/deployment-outputs.json

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The upstream template repository can publish upstream-template-bound prebuilt `l
   - `download-private-release`
   - `run-codedeploy-canary`
   - `reconcile-managed-dsql-endpoint`
+  - `reconcile-project-info`
 - scripts:
   - `scripts/reconcile-managed-dsql-endpoint.sh` - local/manual equivalent of the action
 
@@ -45,6 +46,14 @@ Reusable workflow inputs:
 - `working_directory`
 - `infra_binaries_repo` _(optional, default `Lychee-Technology/ltbase-private-deployment-binaries`)_
 - `reconcile_managed_dsql_endpoint` _(optional, default `false`)_ - when `true`, fetches the authoritative DSQL cluster endpoint from AWS after `pulumi up` and writes it back to Pulumi config as `dsqlEndpoint` before output capture (and before CodeDeploy canaries in `promote-prod`). Required for stacks that use managed Aurora DSQL.
+
+After every successful `pulumi up`, the rollout workflows also reconcile the authservice `project info` item in DynamoDB before output capture. The internal `reconcile-project-info` action reads `projectId`, `apiId`, `apiBaseUrl`, and `tableName` from stack outputs, resolves the current AWS account id with `sts get-caller-identity`, and writes the record with:
+
+- `PK=project#<projectId>`
+- `SK=info`
+- `account_id=<current aws account id>`
+- `api_id=<deployed data plane api id>`
+- `api_base_url=https://<api domain>`
 
 Prebuilt infra binary lookup now reads `blueprint/__ref__/template-provenance.json` from the checked-out deployment repo and matches releases by upstream template repository, upstream template commit, `build_fingerprint`, and runner architecture. If provenance is missing, malformed, delayed, or mismatched, the workflow falls back to source build.
 

--- a/test/generic-workflows-test.sh
+++ b/test/generic-workflows-test.sh
@@ -53,6 +53,7 @@ assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" ".github/ac
 assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "infra_binaries_repo"
 assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "provenance-path: blueprint/__ref__/template-provenance.json"
 assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" ".github/actions/run-pulumi"
+assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" ".github/actions/reconcile-project-info"
 assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "command: up"
 assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "command: refresh"
 assert_file_contains "${ROOT_DIR}/.github/workflows/diagnose-go-compile.yml" "strategy:"

--- a/test/reconcile-project-info-test.sh
+++ b/test/reconcile-project-info-test.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+ACTION_PATH="${ROOT_DIR}/.github/actions/reconcile-project-info/action.yml"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+assert_contains() {
+  local path="$1"
+  local needle="$2"
+  if [[ ! -f "${path}" ]]; then
+    fail "missing file: ${path}"
+  fi
+  if ! grep -Fq "${needle}" "${path}"; then
+    fail "expected ${path} to contain: ${needle}"
+  fi
+}
+
+assert_contains "${ACTION_PATH}" "name: Reconcile Project Info"
+assert_contains "${ACTION_PATH}" "stack:"
+assert_contains "${ACTION_PATH}" "aws-region:"
+assert_contains "${ACTION_PATH}" "working-directory:"
+assert_contains "${ACTION_PATH}" "pulumi stack output projectId"
+assert_contains "${ACTION_PATH}" "pulumi stack output apiId"
+assert_contains "${ACTION_PATH}" "pulumi stack output apiBaseUrl"
+assert_contains "${ACTION_PATH}" "pulumi stack output tableName"
+assert_contains "${ACTION_PATH}" "aws sts get-caller-identity --query Account --output text"
+assert_contains "${ACTION_PATH}" "aws dynamodb put-item"
+assert_contains "${ACTION_PATH}" '"PK":{"S":"project#${project_id}"}'
+assert_contains "${ACTION_PATH}" '"SK":{"S":"info"}'
+assert_contains "${ACTION_PATH}" '"api_id":{"S":"${api_id}"}'
+assert_contains "${ACTION_PATH}" '"api_base_url":{"S":"${api_base_url}"}'
+
+printf 'PASS: reconcile-project-info action tests\n'


### PR DESCRIPTION
## Summary
- add a reusable workflow action that resolves deployed project metadata and writes the authservice-compatible `project info` record into DynamoDB
- run the reconciliation step in `rollout-hop.yml` after `pulumi up` and before deployment output capture so deploy and promote flows stay aligned
- document and test the new workflow behavior