### PR TITLE
feat: deploy control plane ui release artifact

### DIFF
--- a/.github/actions/deploy-controlplane-ui/action.yml
+++ b/.github/actions/deploy-controlplane-ui/action.yml
@@ -1,0 +1,39 @@
+name: Deploy Control Plane UI
+description: Deploy the control plane UI release artifact to Cloudflare Pages
+
+inputs:
+  manifest-path:
+    description: Path to the downloaded release manifest.json file
+    required: true
+  runtime-config-json:
+    description: Runtime config JSON written into the deployed artifact
+    required: true
+  cloudflare-pages-project:
+    description: Cloudflare Pages project name
+    required: true
+  pages-branch:
+    description: Optional Cloudflare Pages branch name
+    required: false
+    default: ""
+  artifact-name:
+    description: Manifest artifact name selector
+    required: false
+    default: controlplane-ui
+  deploy-root:
+    description: Optional unpack directory override
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Deploy control plane UI artifact
+      shell: bash
+      run: |
+        "${{ github.action_path }}/deploy.sh" \
+          --manifest-path "${{ inputs.manifest-path }}" \
+          --runtime-config-json "${{ inputs.runtime-config-json }}" \
+          --cloudflare-pages-project "${{ inputs.cloudflare-pages-project }}" \
+          --pages-branch "${{ inputs.pages-branch }}" \
+          --artifact-name "${{ inputs.artifact-name }}" \
+          --deploy-root "${{ inputs.deploy-root }}"

--- a/.github/actions/deploy-controlplane-ui/aggregate-runtime-config.sh
+++ b/.github/actions/deploy-controlplane-ui/aggregate-runtime-config.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+WORKING_DIRECTORY=""
+TARGET_STACK=""
+CANDIDATE_STACKS=""
+CONTROLPLANE_UI_DOMAIN=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --working-directory)
+      WORKING_DIRECTORY="$2"
+      shift 2
+      ;;
+    --target-stack)
+      TARGET_STACK="$2"
+      shift 2
+      ;;
+    --candidate-stacks)
+      CANDIDATE_STACKS="$2"
+      shift 2
+      ;;
+    --controlplane-ui-domain)
+      CONTROLPLANE_UI_DOMAIN="$2"
+      shift 2
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+for name in WORKING_DIRECTORY TARGET_STACK CANDIDATE_STACKS CONTROLPLANE_UI_DOMAIN; do
+  if [[ -z "${!name:-}" ]]; then
+    echo "${name} is required" >&2
+    exit 1
+  fi
+done
+
+cd "${WORKING_DIRECTORY}"
+
+stacks_json='[]'
+IFS=',' read -r -a stack_list <<< "${CANDIDATE_STACKS}"
+target_in_candidates=false
+
+for raw_stack in "${stack_list[@]}"; do
+  stack="$(printf '%s' "${raw_stack}" | xargs)"
+  if [[ "${stack}" == "${TARGET_STACK}" ]]; then
+    target_in_candidates=true
+    break
+  fi
+done
+
+if [[ "${target_in_candidates}" != true ]]; then
+  echo "candidate stacks must include target stack ${TARGET_STACK}" >&2
+  exit 1
+fi
+
+for raw_stack in "${stack_list[@]}"; do
+  stack="$(printf '%s' "${raw_stack}" | xargs)"
+  if [[ -z "${stack}" ]]; then
+    continue
+  fi
+
+  stack_outputs="$(pulumi stack output --json --stack "${stack}")"
+  stack_config_json="$(printf '%s' "${stack_outputs}" | jq -r '.controlplaneUiStackConfig // empty')"
+
+  if [[ -z "${stack_config_json}" ]]; then
+    if [[ "${stack}" == "${TARGET_STACK}" ]]; then
+      echo "missing controlplaneUiStackConfig for target stack ${TARGET_STACK}" >&2
+      exit 1
+    fi
+    echo "skipping stack ${stack} because controlplaneUiStackConfig is missing" >&2
+    continue
+  fi
+
+  if ! stack_entry="$(printf '%s' "${stack_config_json}" | jq -c --arg redirect_uri "https://${CONTROLPLANE_UI_DOMAIN}/auth/callback" '
+    if type != "object" then
+      error("controlplaneUiStackConfig must decode to an object")
+    elif (.key // "") == "" or (.label // "") == "" or (.projectId // "") == "" or (.authBaseUrl // "") == "" or (.controlPlaneBaseUrl // "") == "" or (.apiBaseUrl // "") == "" or (.oidcClientId // "") == "" or (.authProviders | type != "array") or (.authProviders | length == 0) then
+      error("controlplaneUiStackConfig is incomplete")
+    else
+      . + {redirectUri: $redirect_uri}
+    end')"; then
+    if [[ "${stack}" == "${TARGET_STACK}" ]]; then
+      echo "invalid controlplaneUiStackConfig for target stack ${TARGET_STACK}" >&2
+      exit 1
+    fi
+    echo "skipping stack ${stack} because controlplaneUiStackConfig is invalid" >&2
+    continue
+  fi
+  stacks_json="$(jq -cn --argjson stacks "${stacks_json}" --argjson entry "${stack_entry}" '$stacks + [$entry]')"
+done
+
+jq -cn --argjson stacks "${stacks_json}" '{stacks: $stacks}'

--- a/.github/actions/deploy-controlplane-ui/deploy.sh
+++ b/.github/actions/deploy-controlplane-ui/deploy.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+MANIFEST_PATH=""
+RUNTIME_CONFIG_JSON=""
+CLOUDFLARE_PAGES_PROJECT=""
+PAGES_BRANCH=""
+ARTIFACT_NAME="controlplane-ui"
+DEPLOY_ROOT=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --manifest-path)
+      MANIFEST_PATH="$2"
+      shift 2
+      ;;
+    --runtime-config-json)
+      RUNTIME_CONFIG_JSON="$2"
+      shift 2
+      ;;
+    --cloudflare-pages-project)
+      CLOUDFLARE_PAGES_PROJECT="$2"
+      shift 2
+      ;;
+    --pages-branch)
+      PAGES_BRANCH="$2"
+      shift 2
+      ;;
+    --artifact-name)
+      ARTIFACT_NAME="$2"
+      shift 2
+      ;;
+    --deploy-root)
+      DEPLOY_ROOT="$2"
+      shift 2
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+for name in RUNTIME_CONFIG_JSON CLOUDFLARE_PAGES_PROJECT ARTIFACT_NAME; do
+  if [[ -z "${!name:-}" ]]; then
+    echo "${name} is required" >&2
+    exit 1
+  fi
+done
+
+if [[ ! -f "${MANIFEST_PATH}" ]]; then
+  echo "manifest.json not found: ${MANIFEST_PATH}" >&2
+  exit 1
+fi
+
+if ! printf '%s' "${RUNTIME_CONFIG_JSON}" | jq -e 'type == "object" and (.stacks | type == "array")' >/dev/null; then
+  echo "runtime config JSON must be an object with a stacks array" >&2
+  exit 1
+fi
+
+artifact_file="$(jq -r --arg artifact_name "${ARTIFACT_NAME}" '.artifacts[]? | select(.name == $artifact_name) | .file' "${MANIFEST_PATH}" | head -n 1)"
+
+if [[ -z "${artifact_file}" ]]; then
+  echo "control plane UI artifact entry not found in manifest" >&2
+  exit 1
+fi
+
+release_dir="$(dirname "${MANIFEST_PATH}")"
+artifact_path="${release_dir}/${artifact_file}"
+
+if [[ ! -f "${artifact_path}" ]]; then
+  echo "control plane UI artifact file not found: ${artifact_path}" >&2
+  exit 1
+fi
+
+if [[ -z "${DEPLOY_ROOT}" ]]; then
+  DEPLOY_ROOT="$(mktemp -d)"
+  cleanup_deploy_root=true
+else
+  cleanup_deploy_root=false
+  rm -rf "${DEPLOY_ROOT}"
+  mkdir -p "${DEPLOY_ROOT}"
+fi
+
+if [[ "${cleanup_deploy_root}" == true ]]; then
+  trap 'rm -rf "${DEPLOY_ROOT}"' EXIT
+fi
+
+tar -xzf "${artifact_path}" -C "${DEPLOY_ROOT}"
+
+pages_dir="${DEPLOY_ROOT}/dist"
+if [[ ! -d "${pages_dir}" ]]; then
+  echo "control plane UI artifact must be a tar.gz archive containing a top-level dist/ directory" >&2
+  exit 1
+fi
+
+printf '%s' "${RUNTIME_CONFIG_JSON}" > "${pages_dir}/ltbase-controlplane.config.json"
+
+if ! command -v wrangler >/dev/null 2>&1; then
+  npm install --global wrangler >/dev/null
+fi
+
+deploy_args=(pages deploy "${pages_dir}" --project-name "${CLOUDFLARE_PAGES_PROJECT}")
+if [[ -n "${PAGES_BRANCH}" ]]; then
+  deploy_args+=(--branch "${PAGES_BRANCH}")
+fi
+
+wrangler "${deploy_args[@]}"

--- a/.github/workflows/deploy-devo.yml
+++ b/.github/workflows/deploy-devo.yml
@@ -40,6 +40,15 @@ on:
           calls aws dsql get-cluster to fetch the authoritative endpoint,
           and writes it back as pulumi config dsqlEndpoint before the
           deployment outputs step.
+      controlplane_ui_domain:
+        type: string
+        required: false
+      controlplane_ui_pages_project:
+        type: string
+        required: false
+      controlplane_ui_stacks:
+        type: string
+        required: false
     secrets:
       aws_role_arn:
         required: true
@@ -76,6 +85,9 @@ jobs:
       run_canary: false
       refresh_after_apply: false
       reconcile_managed_dsql_endpoint: ${{ inputs.reconcile_managed_dsql_endpoint }}
+      controlplane_ui_domain: ${{ inputs.controlplane_ui_domain }}
+      controlplane_ui_pages_project: ${{ inputs.controlplane_ui_pages_project }}
+      controlplane_ui_stacks: ${{ inputs.controlplane_ui_stacks }}
     secrets:
       aws_role_arn: ${{ secrets.aws_role_arn }}
       ltbase_releases_token: ${{ secrets.ltbase_releases_token }}

--- a/.github/workflows/promote-prod.yml
+++ b/.github/workflows/promote-prod.yml
@@ -40,6 +40,15 @@ on:
           calls aws dsql get-cluster to fetch the authoritative endpoint,
           and writes it back as pulumi config dsqlEndpoint. Runs after the
           first pulumi up and before the CodeDeploy canary steps.
+      controlplane_ui_domain:
+        type: string
+        required: false
+      controlplane_ui_pages_project:
+        type: string
+        required: false
+      controlplane_ui_stacks:
+        type: string
+        required: false
     secrets:
       aws_role_arn:
         required: true
@@ -76,6 +85,9 @@ jobs:
       run_canary: true
       refresh_after_apply: true
       reconcile_managed_dsql_endpoint: ${{ inputs.reconcile_managed_dsql_endpoint }}
+      controlplane_ui_domain: ${{ inputs.controlplane_ui_domain }}
+      controlplane_ui_pages_project: ${{ inputs.controlplane_ui_pages_project }}
+      controlplane_ui_stacks: ${{ inputs.controlplane_ui_stacks }}
     secrets:
       aws_role_arn: ${{ secrets.aws_role_arn }}
       ltbase_releases_token: ${{ secrets.ltbase_releases_token }}

--- a/.github/workflows/rollout-hop.yml
+++ b/.github/workflows/rollout-hop.yml
@@ -54,6 +54,15 @@ on:
           calls aws dsql get-cluster to fetch the authoritative endpoint,
           and writes it back as pulumi config dsqlEndpoint before output
           capture and any CodeDeploy canary steps.
+      controlplane_ui_domain:
+        type: string
+        required: false
+      controlplane_ui_pages_project:
+        type: string
+        required: false
+      controlplane_ui_stacks:
+        type: string
+        required: false
     secrets:
       aws_role_arn:
         required: true
@@ -229,6 +238,30 @@ jobs:
           stack: ${{ inputs.pulumi_stack }}
           prefer-wrapper: true
           wrapper-path: scripts/pulumi-wrapper.sh
+      - name: Capture refreshed deployment outputs
+        if: ${{ inputs.refresh_after_apply }}
+        working-directory: blueprint/${{ inputs.working_directory }}
+        run: pulumi stack output --json --stack "${{ inputs.pulumi_stack }}" > /tmp/deployment-outputs.json
+      - name: Aggregate control plane UI config
+        id: controlplane_ui_config
+        if: ${{ inputs.controlplane_ui_domain != '' && inputs.controlplane_ui_pages_project != '' && inputs.controlplane_ui_stacks != '' }}
+        working-directory: blueprint/${{ inputs.working_directory }}
+        run: |
+          runtime_config_json="$("${{ github.workspace }}/.ltbase/workflow-repo/.github/actions/deploy-controlplane-ui/aggregate-runtime-config.sh" \
+            --working-directory "$(pwd)" \
+            --target-stack "${{ inputs.pulumi_stack }}" \
+            --candidate-stacks "${{ inputs.controlplane_ui_stacks }}" \
+            --controlplane-ui-domain "${{ inputs.controlplane_ui_domain }}")"
+          printf 'runtime_config_json=%s\n' "${runtime_config_json}" >> "$GITHUB_OUTPUT"
+      - name: Deploy control plane UI
+        if: ${{ inputs.controlplane_ui_domain != '' && inputs.controlplane_ui_pages_project != '' && inputs.controlplane_ui_stacks != '' }}
+        uses: ./.ltbase/workflow-repo/.github/actions/deploy-controlplane-ui
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.cloudflare_api_token }}
+        with:
+          manifest-path: ${{ steps.download.outputs.manifest_path }}
+          runtime-config-json: ${{ steps.controlplane_ui_config.outputs.runtime_config_json }}
+          cloudflare-pages-project: ${{ inputs.controlplane_ui_pages_project }}
       - id: outputs
         run: |
           echo "deployment_outputs_json=$(jq -c '.' /tmp/deployment-outputs.json)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: Test Workflows Repo
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  shell-tests:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - name: Run workflow structure tests
+        run: bash test/generic-workflows-test.sh
+      - name: Run control plane UI deploy action tests
+        run: bash test/deploy-controlplane-ui-test.sh
+      - name: Run control plane UI aggregation tests
+        run: bash test/aggregate-controlplane-ui-config-test.sh

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The upstream template repository can publish upstream-template-bound prebuilt `l
 - composite actions:
   - `setup-pulumi`
   - `download-private-release`
+  - `deploy-controlplane-ui`
   - `run-codedeploy-canary`
   - `reconcile-managed-dsql-endpoint`
   - `reconcile-project-info`
@@ -46,6 +47,9 @@ Reusable workflow inputs:
 - `working_directory`
 - `infra_binaries_repo` _(optional, default `Lychee-Technology/ltbase-private-deployment-binaries`)_
 - `reconcile_managed_dsql_endpoint` _(optional, default `false`)_ - when `true`, fetches the authoritative DSQL cluster endpoint from AWS after `pulumi up` and writes it back to Pulumi config as `dsqlEndpoint` before output capture (and before CodeDeploy canaries in `promote-prod`). Required for stacks that use managed Aurora DSQL.
+- `controlplane_ui_domain` _(optional)_ - shared Cloudflare Pages custom domain used to derive `redirectUri=https://<domain>/auth/callback` for every included stack.
+- `controlplane_ui_pages_project` _(optional)_ - shared Cloudflare Pages project that should receive the official control plane UI release artifact.
+- `controlplane_ui_stacks` _(optional)_ - comma-separated stack list to inspect after rollout. The deployed stack must be included. Stacks missing `controlplaneUiStackConfig` are skipped unless they are the current rollout target.
 
 After every successful `pulumi up`, the rollout workflows also reconcile the authservice `project info` item in DynamoDB before output capture. The internal `reconcile-project-info` action reads `projectId`, `apiId`, `apiBaseUrl`, and `tableName` from stack outputs, resolves the current AWS account id with `sts get-caller-identity`, and writes the record with:
 
@@ -62,6 +66,24 @@ Reusable workflow secrets:
 - `aws_role_arn`
 - `ltbase_releases_token`
 - `cloudflare_api_token`
+
+## Control Plane UI Rollout
+
+`rollout-hop.yml` can now publish the official control plane UI artifact to Cloudflare Pages after the backend rollout, any CodeDeploy canaries, and any optional `pulumi refresh` succeed.
+
+The rollout path stays opt-in. UI deployment only runs when all three optional inputs are supplied:
+
+- `controlplane_ui_domain`
+- `controlplane_ui_pages_project`
+- `controlplane_ui_stacks`
+
+Preview remains infra-only and never deploys the UI.
+
+The runtime config is built by reading `pulumi stack output --json` for every stack in `controlplane_ui_stacks`, extracting `controlplaneUiStackConfig`, adding `redirectUri`, and deploying a final `ltbase-controlplane.config.json` with only the stacks that currently expose a complete output contract. If the current rollout target is missing `controlplaneUiStackConfig`, the workflow fails.
+
+The deploy action currently expects a release artifact manifest entry named `controlplane-ui` that points to a `tar.gz` archive with a top-level `dist/` directory.
+
+Important: that artifact is not yet part of the currently documented release contract in `ltbase.api` / `ltbase-releases`. This rollout path therefore depends on a separate release-contract change landing first.
 
 ## Version Policy
 
@@ -84,6 +106,9 @@ jobs:
       releases_repo: Lychee-Technology/ltbase-releases
       working_directory: infra
       reconcile_managed_dsql_endpoint: true
+      controlplane_ui_domain: ${{ vars.CONTROLPLANE_UI_DOMAIN }}
+      controlplane_ui_pages_project: ${{ vars.CONTROLPLANE_UI_PAGES_PROJECT }}
+      controlplane_ui_stacks: ${{ vars.STACKS }}
     secrets:
       aws_role_arn: ${{ secrets.AWS_ROLE_ARN_DEVO }}
       ltbase_releases_token: ${{ secrets.LTBASE_RELEASES_TOKEN }}

--- a/test/aggregate-controlplane-ui-config-test.sh
+++ b/test/aggregate-controlplane-ui-config-test.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_PATH="${ROOT_DIR}/.github/actions/deploy-controlplane-ui/aggregate-runtime-config.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+assert_equals() {
+  local expected="$1"
+  local actual="$2"
+  if [[ "${expected}" != "${actual}" ]]; then
+    fail "expected ${expected}, got ${actual}"
+  fi
+}
+
+assert_file_contains() {
+  local path="$1"
+  local needle="$2"
+  if [[ ! -f "${path}" ]]; then
+    fail "missing file: ${path}"
+  fi
+  if ! grep -Fq "${needle}" "${path}"; then
+    fail "expected ${path} to contain: ${needle}"
+  fi
+}
+
+assert_log_contains() {
+  local path="$1"
+  local needle="$2"
+  if ! grep -Fq "${needle}" "${path}"; then
+    fail "expected ${path} to contain: ${needle}"
+  fi
+}
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+fake_bin="${temp_dir}/bin"
+mkdir -p "${fake_bin}" "${temp_dir}/infra"
+
+cat >"${fake_bin}/pulumi" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$1" != "stack" || "$2" != "output" || "$3" != "--json" || "$4" != "--stack" ]]; then
+  printf 'unexpected pulumi args: %s\n' "$*" >&2
+  exit 1
+fi
+
+stack="$5"
+output_path="${PULUMI_OUTPUT_DIR}/${stack}.json"
+if [[ ! -f "${output_path}" ]]; then
+  printf 'missing fake pulumi output for %s\n' "${stack}" >&2
+  exit 1
+fi
+
+cat "${output_path}"
+EOF
+chmod +x "${fake_bin}/pulumi"
+
+cat >"${temp_dir}/infra/devo.json" <<'EOF'
+{}
+EOF
+
+if PATH="${fake_bin}:$PATH" PULUMI_OUTPUT_DIR="${temp_dir}/infra" "${SCRIPT_PATH}" \
+  --working-directory "${temp_dir}/infra" \
+  --target-stack devo \
+  --candidate-stacks devo,prod \
+  --controlplane-ui-domain ui.example.com >"${temp_dir}/missing-target.log" 2>&1; then
+  fail "expected aggregation to fail when target stack config is missing"
+fi
+
+assert_log_contains "${temp_dir}/missing-target.log" "missing controlplaneUiStackConfig for target stack devo"
+
+if PATH="${fake_bin}:$PATH" PULUMI_OUTPUT_DIR="${temp_dir}/infra" "${SCRIPT_PATH}" \
+  --working-directory "${temp_dir}/infra" \
+  --target-stack devo \
+  --candidate-stacks prod \
+  --controlplane-ui-domain ui.example.com >"${temp_dir}/omitted-target.log" 2>&1; then
+  fail "expected aggregation to fail when candidate stacks omit the target stack"
+fi
+
+assert_log_contains "${temp_dir}/omitted-target.log" "candidate stacks must include target stack devo"
+
+cat >"${temp_dir}/infra/devo.json" <<'EOF'
+{
+  "controlplaneUiStackConfig": "{\"key\":\"devo\",\"label\":\"Devo\",\"projectId\":\"p1\",\"authBaseUrl\":\"https://auth.devo\",\"controlPlaneBaseUrl\":\"https://cp.devo\",\"apiBaseUrl\":\"https://api.devo\",\"oidcClientId\":\"oidc-devo\",\"authProviders\":[{\"type\":\"firebase\",\"name\":\"firebase\",\"label\":\"Firebase\",\"firebaseProjectId\":\"fb-devo\",\"firebaseApiKey\":\"key-devo\"}]}"
+}
+EOF
+
+cat >"${temp_dir}/infra/prod.json" <<'EOF'
+{}
+EOF
+
+actual_json="$(PATH="${fake_bin}:$PATH" PULUMI_OUTPUT_DIR="${temp_dir}/infra" "${SCRIPT_PATH}" \
+  --working-directory "${temp_dir}/infra" \
+  --target-stack devo \
+  --candidate-stacks devo,prod \
+  --controlplane-ui-domain ui.example.com 2>"${temp_dir}/skip.log")"
+
+assert_log_contains "${temp_dir}/skip.log" "skipping stack prod because controlplaneUiStackConfig is missing"
+expected_skip_json='{"stacks":[{"key":"devo","label":"Devo","projectId":"p1","authBaseUrl":"https://auth.devo","controlPlaneBaseUrl":"https://cp.devo","apiBaseUrl":"https://api.devo","oidcClientId":"oidc-devo","authProviders":[{"type":"firebase","name":"firebase","label":"Firebase","firebaseProjectId":"fb-devo","firebaseApiKey":"key-devo"}],"redirectUri":"https://ui.example.com/auth/callback"}]}'
+assert_equals "${expected_skip_json}" "${actual_json}"
+
+cat >"${temp_dir}/infra/prod.json" <<'EOF'
+{
+  "controlplaneUiStackConfig": "{\"key\":\"prod\",\"label\":\"Prod\",\"projectId\":\"p2\",\"authBaseUrl\":\"https://auth.prod\",\"controlPlaneBaseUrl\":\"https://cp.prod\",\"apiBaseUrl\":\"https://api.prod\",\"oidcClientId\":\"oidc-prod\",\"authProviders\":[{\"type\":\"supabase\",\"name\":\"supabase\",\"label\":\"Supabase\",\"supabaseUrl\":\"https://supabase.prod\",\"supabaseAnonKey\":\"anon-prod\"}]}"
+}
+EOF
+
+actual_json="$(PATH="${fake_bin}:$PATH" PULUMI_OUTPUT_DIR="${temp_dir}/infra" "${SCRIPT_PATH}" \
+  --working-directory "${temp_dir}/infra" \
+  --target-stack devo \
+  --candidate-stacks devo,prod \
+  --controlplane-ui-domain ui.example.com)"
+
+expected_json='{"stacks":[{"key":"devo","label":"Devo","projectId":"p1","authBaseUrl":"https://auth.devo","controlPlaneBaseUrl":"https://cp.devo","apiBaseUrl":"https://api.devo","oidcClientId":"oidc-devo","authProviders":[{"type":"firebase","name":"firebase","label":"Firebase","firebaseProjectId":"fb-devo","firebaseApiKey":"key-devo"}],"redirectUri":"https://ui.example.com/auth/callback"},{"key":"prod","label":"Prod","projectId":"p2","authBaseUrl":"https://auth.prod","controlPlaneBaseUrl":"https://cp.prod","apiBaseUrl":"https://api.prod","oidcClientId":"oidc-prod","authProviders":[{"type":"supabase","name":"supabase","label":"Supabase","supabaseUrl":"https://supabase.prod","supabaseAnonKey":"anon-prod"}],"redirectUri":"https://ui.example.com/auth/callback"}]}'
+assert_equals "${expected_json}" "${actual_json}"
+
+cat >"${temp_dir}/infra/prod.json" <<'EOF'
+{
+  "controlplaneUiStackConfig": "{\"key\":\"prod\"}"
+}
+EOF
+
+actual_json="$(PATH="${fake_bin}:$PATH" PULUMI_OUTPUT_DIR="${temp_dir}/infra" "${SCRIPT_PATH}" \
+  --working-directory "${temp_dir}/infra" \
+  --target-stack devo \
+  --candidate-stacks devo,prod \
+  --controlplane-ui-domain ui.example.com 2>"${temp_dir}/invalid-nontarget.log")"
+
+assert_log_contains "${temp_dir}/invalid-nontarget.log" "skipping stack prod because controlplaneUiStackConfig is invalid"
+assert_equals "${expected_skip_json}" "${actual_json}"
+
+cat >"${temp_dir}/infra/devo.json" <<'EOF'
+{
+  "controlplaneUiStackConfig": "{\"key\":\"devo\"}"
+}
+EOF
+
+if PATH="${fake_bin}:$PATH" PULUMI_OUTPUT_DIR="${temp_dir}/infra" "${SCRIPT_PATH}" \
+  --working-directory "${temp_dir}/infra" \
+  --target-stack devo \
+  --candidate-stacks devo,prod \
+  --controlplane-ui-domain ui.example.com >"${temp_dir}/invalid-target.log" 2>&1; then
+  fail "expected aggregation to fail when target stack config is invalid"
+fi
+
+assert_log_contains "${temp_dir}/invalid-target.log" "invalid controlplaneUiStackConfig for target stack devo"
+assert_file_contains "${SCRIPT_PATH}" "controlplaneUiStackConfig"
+assert_file_contains "${SCRIPT_PATH}" "redirectUri"
+
+printf 'PASS: aggregate-controlplane-ui-config tests\n'

--- a/test/deploy-controlplane-ui-test.sh
+++ b/test/deploy-controlplane-ui-test.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+ACTION_PATH="${ROOT_DIR}/.github/actions/deploy-controlplane-ui/action.yml"
+SCRIPT_PATH="${ROOT_DIR}/.github/actions/deploy-controlplane-ui/deploy.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+assert_file_contains() {
+  local path="$1"
+  local needle="$2"
+  if [[ ! -f "${path}" ]]; then
+    fail "missing file: ${path}"
+  fi
+  if ! grep -Fq "${needle}" "${path}"; then
+    fail "expected ${path} to contain: ${needle}"
+  fi
+}
+
+assert_log_contains() {
+  local path="$1"
+  local needle="$2"
+  if ! grep -Fq "${needle}" "${path}"; then
+    fail "expected ${path} to contain: ${needle}"
+  fi
+}
+
+assert_file_equals() {
+  local path="$1"
+  local expected="$2"
+  local actual
+  actual="$(<"${path}")"
+  if [[ "${actual}" != "${expected}" ]]; then
+    fail "expected ${path} to equal ${expected}, got ${actual}"
+  fi
+}
+
+run_expect_fail() {
+  local expected="$1"
+  shift
+  local log_file="$1"
+  shift
+
+  if "$@" >"${log_file}" 2>&1; then
+    fail "expected command to fail: $*"
+  fi
+
+  assert_log_contains "${log_file}" "${expected}"
+}
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+fake_bin="${temp_dir}/bin"
+log_file="${temp_dir}/commands.log"
+mkdir -p "${fake_bin}"
+touch "${log_file}"
+
+manifest_path="${temp_dir}/manifest.json"
+
+create_tarball() {
+  local tarball_path="$1"
+  local content_root="${temp_dir}/artifact-content"
+  rm -rf "${content_root}"
+  mkdir -p "${content_root}/dist"
+  printf '<html>ok</html>\n' >"${content_root}/dist/index.html"
+  tar -czf "${tarball_path}" -C "${content_root}" .
+}
+
+create_invalid_layout_tarball() {
+  local tarball_path="$1"
+  local content_root="${temp_dir}/invalid-artifact-content"
+  rm -rf "${content_root}"
+  mkdir -p "${content_root}/public"
+  printf '<html>wrong-layout</html>\n' >"${content_root}/public/index.html"
+  tar -czf "${tarball_path}" -C "${content_root}" .
+}
+
+cat >"${fake_bin}/wrangler" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'wrangler %s\n' "$*" >>"${COMMAND_LOG}"
+EOF
+chmod +x "${fake_bin}/wrangler"
+
+create_manifest() {
+  local artifact_file="$1"
+  cat >"${manifest_path}" <<EOF
+{
+  "release_id": "v1.2.3",
+  "artifacts": [
+    {
+      "name": "controlplane-ui",
+      "file": "${artifact_file}",
+      "sha256": "unused"
+    }
+  ]
+}
+EOF
+}
+
+runtime_config='{"stacks":[{"key":"devo","redirectUri":"https://ui.example.com/auth/callback"}]}'
+
+run_expect_fail "manifest.json not found" "${temp_dir}/missing-manifest.log" \
+  env PATH="${fake_bin}:$PATH" COMMAND_LOG="${log_file}" "${SCRIPT_PATH}" \
+    --manifest-path "${temp_dir}/does-not-exist.json" \
+    --runtime-config-json "${runtime_config}" \
+    --cloudflare-pages-project "cp-ui"
+
+cat >"${manifest_path}" <<'EOF'
+{"release_id":"v1.2.3","artifacts":[]}
+EOF
+run_expect_fail "control plane UI artifact entry not found in manifest" "${temp_dir}/missing-artifact.log" \
+  env PATH="${fake_bin}:$PATH" COMMAND_LOG="${log_file}" "${SCRIPT_PATH}" \
+    --manifest-path "${manifest_path}" \
+    --runtime-config-json "${runtime_config}" \
+    --cloudflare-pages-project "cp-ui"
+
+create_manifest "controlplane-ui.tar.gz"
+run_expect_fail "control plane UI artifact file not found" "${temp_dir}/missing-file.log" \
+  env PATH="${fake_bin}:$PATH" COMMAND_LOG="${log_file}" "${SCRIPT_PATH}" \
+    --manifest-path "${manifest_path}" \
+    --runtime-config-json "${runtime_config}" \
+    --cloudflare-pages-project "cp-ui"
+
+create_tarball "${temp_dir}/controlplane-ui.tar.gz"
+run_expect_fail "runtime config JSON must be an object with a stacks array" "${temp_dir}/invalid-json.log" \
+  env PATH="${fake_bin}:$PATH" COMMAND_LOG="${log_file}" "${SCRIPT_PATH}" \
+    --manifest-path "${manifest_path}" \
+    --runtime-config-json '{"stacks":"bad"}' \
+    --cloudflare-pages-project "cp-ui"
+
+create_invalid_layout_tarball "${temp_dir}/controlplane-ui.tar.gz"
+run_expect_fail "control plane UI artifact must be a tar.gz archive containing a top-level dist/ directory" "${temp_dir}/invalid-layout.log" \
+  env PATH="${fake_bin}:$PATH" COMMAND_LOG="${log_file}" "${SCRIPT_PATH}" \
+    --manifest-path "${manifest_path}" \
+    --runtime-config-json "${runtime_config}" \
+    --cloudflare-pages-project "cp-ui"
+
+create_tarball "${temp_dir}/controlplane-ui.tar.gz"
+
+: >"${log_file}"
+deploy_root="${temp_dir}/deploy-root"
+env PATH="${fake_bin}:$PATH" COMMAND_LOG="${log_file}" "${SCRIPT_PATH}" \
+  --manifest-path "${manifest_path}" \
+  --runtime-config-json "${runtime_config}" \
+  --cloudflare-pages-project "cp-ui" \
+  --pages-branch "main" \
+  --deploy-root "${deploy_root}"
+
+assert_log_contains "${log_file}" "wrangler pages deploy ${deploy_root}/dist --project-name cp-ui --branch main"
+assert_file_equals "${deploy_root}/dist/ltbase-controlplane.config.json" "${runtime_config}"
+assert_file_contains "${ACTION_PATH}" "runtime-config-json"
+assert_file_contains "${ACTION_PATH}" "cloudflare-pages-project"
+assert_file_contains "${ACTION_PATH}" "pages-branch"
+
+printf 'PASS: deploy-controlplane-ui tests\n'

--- a/test/generic-workflows-test.sh
+++ b/test/generic-workflows-test.sh
@@ -31,6 +31,17 @@ assert_file_contains() {
   fi
 }
 
+assert_file_not_contains() {
+  local path="$1"
+  local needle="$2"
+  if [[ ! -f "${path}" ]]; then
+    fail "missing file: ${path}"
+  fi
+  if grep -Fq "${needle}" "${path}"; then
+    fail "expected ${path} to not contain: ${needle}"
+  fi
+}
+
 assert_file_contains "${ROOT_DIR}/.github/workflows/preview-stack.yml" "name: Preview Stack"
 assert_file_contains "${ROOT_DIR}/.github/workflows/preview-stack.yml" "pulumi_secrets_provider"
 assert_file_contains "${ROOT_DIR}/.github/workflows/preview-stack.yml" "workflow_actions_ref"
@@ -66,16 +77,43 @@ assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "provenance
 assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" ".github/actions/run-pulumi"
 assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" ".github/actions/reconcile-project-info"
 assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "reconcile_managed_dsql_endpoint"
+assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "controlplane_ui_domain"
+assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "controlplane_ui_pages_project"
+assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "controlplane_ui_stacks"
+assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" ".github/actions/deploy-controlplane-ui"
+assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "name: Aggregate control plane UI config"
+assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "name: Deploy control plane UI"
+assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "runtime-config-json: \${{ steps.controlplane_ui_config.outputs.runtime_config_json }}"
+assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "cloudflare-pages-project: \${{ inputs.controlplane_ui_pages_project }}"
 assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "name: Re-apply stack after managed DSQL reconcile"
 assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "if: \${{ inputs.reconcile_managed_dsql_endpoint }}"
 assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "command: up"
 assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "command: refresh"
+assert_file_contains "${ROOT_DIR}/.github/workflows/deploy-devo.yml" "controlplane_ui_domain"
+assert_file_contains "${ROOT_DIR}/.github/workflows/deploy-devo.yml" "controlplane_ui_pages_project"
+assert_file_contains "${ROOT_DIR}/.github/workflows/deploy-devo.yml" "controlplane_ui_stacks"
+assert_file_contains "${ROOT_DIR}/.github/workflows/promote-prod.yml" "controlplane_ui_domain"
+assert_file_contains "${ROOT_DIR}/.github/workflows/promote-prod.yml" "controlplane_ui_pages_project"
+assert_file_contains "${ROOT_DIR}/.github/workflows/promote-prod.yml" "controlplane_ui_stacks"
+assert_file_contains "${ROOT_DIR}/.github/workflows/preview-stack.yml" "name: Preview Stack"
+
+if grep -Fq ".github/actions/deploy-controlplane-ui" "${ROOT_DIR}/.github/workflows/preview-stack.yml"; then
+  fail "preview-stack workflow must not reference the control plane UI deploy action"
+fi
+
+if grep -Fq "controlplane_ui_domain" "${ROOT_DIR}/.github/workflows/preview-stack.yml"; then
+  fail "preview-stack workflow must remain infra-only"
+fi
 
 reconcile_line="$(line_number_for "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "- name: Reconcile managed DSQL endpoint")"
 reapply_line="$(line_number_for "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "- name: Re-apply stack after managed DSQL reconcile")"
 project_info_line="$(line_number_for "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "- name: Reconcile project info")"
 outputs_line="$(line_number_for "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "- name: Capture deployment outputs")"
 canary_line="$(line_number_for "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "- name: Run data plane canary")"
+refresh_line="$(line_number_for "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "- name: Refresh stack")"
+refresh_outputs_line="$(line_number_for "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "- name: Capture refreshed deployment outputs")"
+ui_config_line="$(line_number_for "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "- name: Aggregate control plane UI config")"
+ui_deploy_line="$(line_number_for "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "- name: Deploy control plane UI")"
 
 if (( reconcile_line >= reapply_line )); then
   fail "expected managed DSQL reconcile to happen before second apply"
@@ -89,6 +127,16 @@ fi
 if (( outputs_line >= canary_line )); then
   fail "expected output capture to happen before canary steps"
 fi
+if (( canary_line >= refresh_outputs_line )); then
+  fail "expected refreshed output capture to happen after canary steps"
+fi
+if (( refresh_outputs_line >= ui_config_line )); then
+  fail "expected UI config aggregation to happen after refreshed output capture"
+fi
+if (( ui_config_line >= ui_deploy_line )); then
+  fail "expected UI deploy to happen after UI config aggregation"
+fi
+assert_file_not_contains "${ROOT_DIR}/.github/workflows/preview.yml" "deploy-controlplane-ui"
 assert_file_contains "${ROOT_DIR}/.github/workflows/diagnose-go-compile.yml" "strategy:"
 assert_file_contains "${ROOT_DIR}/.github/workflows/diagnose-go-compile.yml" "ubuntu-24.04-arm"
 assert_file_contains "${ROOT_DIR}/.github/workflows/diagnose-go-compile.yml" "ubuntu-24.04"
@@ -97,6 +145,10 @@ assert_file_contains "${ROOT_DIR}/.github/workflows/diagnose-go-compile.yml" "bl
 assert_file_contains "${ROOT_DIR}/.github/workflows/diagnose-go-compile.yml" "repository: \${{ inputs.blueprint_repository }}"
 assert_file_contains "${ROOT_DIR}/.github/workflows/diagnose-go-compile.yml" ".github/actions/download-private-release"
 assert_file_contains "${ROOT_DIR}/.github/workflows/diagnose-go-compile.yml" "token: \${{ secrets.LTBASE_RELEASES_TOKEN }}"
+assert_file_contains "${ROOT_DIR}/.github/workflows/test.yml" "name: Test Workflows Repo"
+assert_file_contains "${ROOT_DIR}/.github/workflows/test.yml" "bash test/generic-workflows-test.sh"
+assert_file_contains "${ROOT_DIR}/.github/workflows/test.yml" "bash test/deploy-controlplane-ui-test.sh"
+assert_file_contains "${ROOT_DIR}/.github/workflows/test.yml" "bash test/aggregate-controlplane-ui-config-test.sh"
 assert_file_contains "${ROOT_DIR}/.github/workflows/deploy-devo.yml" ".github/workflows/rollout-hop.yml@"
 assert_file_contains "${ROOT_DIR}/.github/workflows/promote-prod.yml" ".github/workflows/rollout-hop.yml@"
 assert_file_contains "${ROOT_DIR}/.github/workflows/preview.yml" ".github/workflows/preview-stack.yml@"


### PR DESCRIPTION
## Summary
- add a rollout-only control plane UI deploy action for release artifacts
- aggregate multi-stack runtime config from `controlplaneUiStackConfig` Pulumi outputs
- publish the UI only after canaries and optional refresh succeed
- add shell regression coverage plus a PR test workflow
- document the new rollout interface and external artifact dependency

## Testing
- bash test/generic-workflows-test.sh
- bash test/deploy-controlplane-ui-test.sh
- bash test/aggregate-controlplane-ui-config-test.sh

## Related
- Closes #17
- Depends on the deployment-template contract PR: https://github.com/Lychee-Technology/ltbase-private-deployment/pull/85

## Notes
The rollout path still depends on an external release-contract change in `ltbase.api` / `ltbase-releases`. Until the official release bundle includes a `controlplane-ui` artifact, runtime deployment will fail with the documented artifact validation errors.