### PR TITLE
feat: deploy controlplane ui from release artifact

### DIFF
--- a/.github/actions/deploy-controlplane-ui/action.yml
+++ b/.github/actions/deploy-controlplane-ui/action.yml
@@ -1,0 +1,39 @@
+name: Deploy Control Plane UI
+description: Deploy the official Control Plane UI release artifact to Cloudflare Pages
+
+inputs:
+  release-dir:
+    description: Local directory containing downloaded release assets
+    required: true
+  manifest-path:
+    description: Path to the validated release manifest.json
+    required: true
+  pages-project:
+    description: Cloudflare Pages project name to publish into
+    required: true
+  cloudflare-account-id:
+    description: Cloudflare account id owning the Pages project
+    required: true
+  runtime-config-path:
+    description: Path to ltbase-controlplane.config.json rendered by the caller repo
+    required: true
+  artifact-name:
+    description: Artifact name entry in manifest.json for the Control Plane UI site bundle
+    required: false
+    default: controlplane-ui
+
+runs:
+  using: composite
+  steps:
+    - name: Deploy Control Plane UI site
+      shell: bash
+      env:
+        CLOUDFLARE_ACCOUNT_ID: ${{ inputs.cloudflare-account-id }}
+      run: |
+        "${{ github.action_path }}/deploy.sh" \
+          --release-dir "${{ inputs.release-dir }}" \
+          --manifest-path "${{ inputs.manifest-path }}" \
+          --pages-project "${{ inputs.pages-project }}" \
+          --cloudflare-account-id "${{ inputs.cloudflare-account-id }}" \
+          --runtime-config-path "${{ inputs.runtime-config-path }}" \
+          --artifact-name "${{ inputs.artifact-name }}"

--- a/.github/actions/deploy-controlplane-ui/deploy.sh
+++ b/.github/actions/deploy-controlplane-ui/deploy.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+RELEASE_DIR=""
+MANIFEST_PATH=""
+PAGES_PROJECT=""
+CLOUDFLARE_ACCOUNT_ID_INPUT=""
+RUNTIME_CONFIG_PATH=""
+ARTIFACT_NAME="controlplane-ui"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --release-dir)
+      RELEASE_DIR="$2"
+      shift 2
+      ;;
+    --manifest-path)
+      MANIFEST_PATH="$2"
+      shift 2
+      ;;
+    --pages-project)
+      PAGES_PROJECT="$2"
+      shift 2
+      ;;
+    --cloudflare-account-id)
+      CLOUDFLARE_ACCOUNT_ID_INPUT="$2"
+      shift 2
+      ;;
+    --runtime-config-path)
+      RUNTIME_CONFIG_PATH="$2"
+      shift 2
+      ;;
+    --artifact-name)
+      ARTIFACT_NAME="$2"
+      shift 2
+      ;;
+    *)
+      printf 'unknown argument: %s\n' "$1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+for name in RELEASE_DIR MANIFEST_PATH PAGES_PROJECT CLOUDFLARE_ACCOUNT_ID_INPUT RUNTIME_CONFIG_PATH ARTIFACT_NAME; do
+  if [[ -z "${!name}" ]]; then
+    printf '%s is required\n' "${name}" >&2
+    exit 1
+  fi
+done
+
+if [[ ! -f "${MANIFEST_PATH}" ]]; then
+  printf 'manifest not found: %s\n' "${MANIFEST_PATH}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${RUNTIME_CONFIG_PATH}" ]]; then
+  printf 'runtime config not found: %s\n' "${RUNTIME_CONFIG_PATH}" >&2
+  exit 1
+fi
+
+artifact_file="$(jq -r --arg name "${ARTIFACT_NAME}" '.artifacts[]? | select(.name == $name) | .file' "${MANIFEST_PATH}")"
+if [[ -z "${artifact_file}" || "${artifact_file}" == "null" ]]; then
+  printf 'UI artifact manifest entry not found for name: %s\n' "${ARTIFACT_NAME}" >&2
+  exit 1
+fi
+
+artifact_path="${RELEASE_DIR}/${artifact_file}"
+if [[ ! -f "${artifact_path}" ]]; then
+  printf 'UI artifact file not found: %s\n' "${artifact_path}" >&2
+  exit 1
+fi
+
+site_dir="$(dirname "${RELEASE_DIR}")/site"
+rm -rf "${site_dir}"
+mkdir -p "${site_dir}"
+
+tar -xzf "${artifact_path}" -C "${site_dir}"
+cp "${RUNTIME_CONFIG_PATH}" "${site_dir}/ltbase-controlplane.config.json"
+
+wrangler pages deploy "${site_dir}" --project-name "${PAGES_PROJECT}"

--- a/.github/workflows/rollout-hop.yml
+++ b/.github/workflows/rollout-hop.yml
@@ -25,6 +25,22 @@ on:
         type: string
         required: false
         default: Lychee-Technology/ltbase-releases
+      controlplane_ui_pages_project:
+        type: string
+        required: false
+        default: ""
+      controlplane_ui_runtime_config_path:
+        type: string
+        required: false
+        default: ""
+      controlplane_ui_runtime_config_json:
+        type: string
+        required: false
+        default: ""
+      controlplane_ui_artifact_name:
+        type: string
+        required: false
+        default: controlplane-ui
       working_directory:
         type: string
         required: false
@@ -182,6 +198,28 @@ jobs:
       - name: Capture deployment outputs
         working-directory: blueprint/${{ inputs.working_directory }}
         run: pulumi stack output --json --stack "${{ inputs.pulumi_stack }}" > /tmp/deployment-outputs.json
+      - name: Materialize Control Plane UI runtime config
+        if: ${{ inputs.controlplane_ui_pages_project != '' }}
+        env:
+          CONTROLPLANE_UI_RUNTIME_CONFIG_JSON: ${{ inputs.controlplane_ui_runtime_config_json }}
+        run: |
+          if [[ -z "${CONTROLPLANE_UI_RUNTIME_CONFIG_JSON}" ]]; then
+            echo "controlplane_ui_runtime_config_json is required when controlplane_ui_pages_project is set" >&2
+            exit 1
+          fi
+          runtime_config_path="blueprint/${{ inputs.controlplane_ui_runtime_config_path }}"
+          mkdir -p "$(dirname "${runtime_config_path}")"
+          printf '%s' "${CONTROLPLANE_UI_RUNTIME_CONFIG_JSON}" | jq -c '.' > "${runtime_config_path}"
+      - name: Deploy Control Plane UI
+        if: ${{ inputs.controlplane_ui_pages_project != '' }}
+        uses: ./.ltbase/workflow-repo/.github/actions/deploy-controlplane-ui
+        with:
+          release-dir: ${{ steps.download.outputs.release-dir }}
+          manifest-path: ${{ steps.download.outputs.manifest-path }}
+          pages-project: ${{ inputs.controlplane_ui_pages_project }}
+          cloudflare-account-id: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          runtime-config-path: ${{ format('blueprint/{0}', inputs.controlplane_ui_runtime_config_path) }}
+          artifact-name: ${{ inputs.controlplane_ui_artifact_name }}
       - name: Run data plane canary
         if: ${{ inputs.run_canary }}
         uses: ./.ltbase/workflow-repo/.github/actions/run-codedeploy-canary

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Reusable workflow inputs:
 - `pulumi_backend_url`
 - `pulumi_secrets_provider`
 - `releases_repo`
+- `controlplane_ui_pages_project` _(optional)_ - when set, `rollout-hop.yml` also deploys the Control Plane UI release artifact into this Cloudflare Pages project
+- `controlplane_ui_runtime_config_path` _(optional)_ - caller-managed path to the rendered `ltbase-controlplane.config.json` file injected into the released UI bundle before publish
+- `controlplane_ui_artifact_name` _(optional, default `controlplane-ui`)_ - manifest artifact name to publish as the Control Plane UI site bundle
 - `working_directory`
 - `infra_binaries_repo` _(optional, default `Lychee-Technology/ltbase-private-deployment-binaries`)_
 - `reconcile_managed_dsql_endpoint` _(optional, default `false`)_ - when `true`, fetches the authoritative DSQL cluster endpoint from AWS after `pulumi up` and writes it back to Pulumi config as `dsqlEndpoint` before output capture (and before CodeDeploy canaries in `promote-prod`). Required for stacks that use managed Aurora DSQL.
@@ -62,6 +65,8 @@ Reusable workflow secrets:
 - `aws_role_arn`
 - `ltbase_releases_token`
 - `cloudflare_api_token`
+
+When `controlplane_ui_pages_project` is provided, `rollout-hop.yml` also invokes the `deploy-controlplane-ui` composite action. That action validates the named UI artifact entry from `manifest.json`, unpacks the site bundle, injects the caller-rendered `ltbase-controlplane.config.json`, and publishes it with `wrangler pages deploy`. Preview workflows stay infra-only.
 
 ## Version Policy
 

--- a/test/deploy-controlplane-ui-test.sh
+++ b/test/deploy-controlplane-ui-test.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+ACTION_PATH="${ROOT_DIR}/.github/actions/deploy-controlplane-ui/action.yml"
+SCRIPT_PATH="${ROOT_DIR}/.github/actions/deploy-controlplane-ui/deploy.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+assert_file_contains() {
+  local path="$1"
+  local needle="$2"
+  if [[ ! -f "${path}" ]]; then
+    fail "missing file: ${path}"
+  fi
+  if ! grep -Fq -- "${needle}" "${path}"; then
+    fail "expected ${path} to contain: ${needle}"
+  fi
+}
+
+assert_log_contains() {
+  local path="$1"
+  local needle="$2"
+  if ! grep -Fq -- "${needle}" "${path}"; then
+    fail "expected ${path} to contain: ${needle}"
+  fi
+}
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+fake_bin="${temp_dir}/bin"
+log_file="${temp_dir}/commands.log"
+release_dir="${temp_dir}/release"
+mkdir -p "${fake_bin}" "${release_dir}"
+touch "${log_file}"
+
+assert_file_contains "${ACTION_PATH}" "release-dir"
+assert_file_contains "${ACTION_PATH}" "manifest-path"
+assert_file_contains "${ACTION_PATH}" "pages-project"
+assert_file_contains "${ACTION_PATH}" "cloudflare-account-id"
+assert_file_contains "${ACTION_PATH}" "runtime-config-path"
+assert_file_contains "${ACTION_PATH}" "artifact-name"
+assert_file_contains "${SCRIPT_PATH}" "wrangler pages deploy"
+assert_file_contains "${SCRIPT_PATH}" "ltbase-controlplane.config.json"
+assert_file_contains "${SCRIPT_PATH}" "UI artifact manifest entry not found"
+
+cat >"${release_dir}/manifest.json" <<'EOF'
+{
+  "release_id": "v1.2.3",
+  "artifacts": [
+    {
+      "name": "controlplane-ui",
+      "file": "ltbase-controlplane-ui.tar.gz",
+      "sha256": "dummy"
+    }
+  ]
+}
+EOF
+
+printf '{"stacks":[]}' >"${temp_dir}/ltbase-controlplane.config.json"
+printf 'placeholder' >"${release_dir}/ltbase-controlplane-ui.tar.gz"
+
+cat >"${fake_bin}/tar" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'tar %s\n' "$*" >>"${COMMAND_LOG}"
+dest=""
+args=("$@")
+for i in "${!args[@]}"; do
+  if [[ "${args[$i]}" == "-C" && -n "${args[$((i + 1))]:-}" ]]; then
+    dest="${args[$((i + 1))]}"
+  fi
+done
+mkdir -p "${dest}"
+printf '<html>ok</html>' >"${dest}/index.html"
+EOF
+chmod +x "${fake_bin}/tar"
+
+cat >"${fake_bin}/wrangler" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'wrangler %s\n' "$*" >>"${COMMAND_LOG}"
+EOF
+chmod +x "${fake_bin}/wrangler"
+
+PATH="${fake_bin}:$PATH" COMMAND_LOG="${log_file}" "${SCRIPT_PATH}" \
+  --release-dir "${release_dir}" \
+  --manifest-path "${release_dir}/manifest.json" \
+  --pages-project customer-ltbase-controlplane-ui \
+  --cloudflare-account-id cf-account-123 \
+  --runtime-config-path "${temp_dir}/ltbase-controlplane.config.json" \
+  --artifact-name controlplane-ui
+
+assert_log_contains "${log_file}" "tar -xzf ${release_dir}/ltbase-controlplane-ui.tar.gz"
+assert_log_contains "${log_file}" "wrangler pages deploy"
+assert_log_contains "${log_file}" "--project-name customer-ltbase-controlplane-ui"
+assert_file_contains "${temp_dir}/site/ltbase-controlplane.config.json" '{"stacks":[]}'
+
+if PATH="${fake_bin}:$PATH" COMMAND_LOG="${log_file}" "${SCRIPT_PATH}" \
+  --release-dir "${release_dir}" \
+  --manifest-path "${release_dir}/manifest.json" \
+  --pages-project customer-ltbase-controlplane-ui \
+  --cloudflare-account-id cf-account-123 \
+  --runtime-config-path "${temp_dir}/ltbase-controlplane.config.json" \
+  --artifact-name missing-ui >"${temp_dir}/missing.log" 2>&1; then
+  fail "expected missing UI artifact lookup to fail"
+fi
+
+assert_log_contains "${temp_dir}/missing.log" "UI artifact manifest entry not found"
+
+printf 'PASS: deploy controlplane ui tests\n'

--- a/test/generic-workflows-test.sh
+++ b/test/generic-workflows-test.sh
@@ -31,6 +31,17 @@ assert_file_contains() {
   fi
 }
 
+assert_file_not_contains() {
+  local path="$1"
+  local needle="$2"
+  if [[ ! -f "${path}" ]]; then
+    fail "missing file: ${path}"
+  fi
+  if grep -Fq "${needle}" "${path}"; then
+    fail "expected ${path} to not contain: ${needle}"
+  fi
+}
+
 assert_file_contains "${ROOT_DIR}/.github/workflows/preview-stack.yml" "name: Preview Stack"
 assert_file_contains "${ROOT_DIR}/.github/workflows/preview-stack.yml" "pulumi_secrets_provider"
 assert_file_contains "${ROOT_DIR}/.github/workflows/preview-stack.yml" "workflow_actions_ref"
@@ -48,6 +59,7 @@ assert_file_contains "${ROOT_DIR}/.github/workflows/preview-stack.yml" "infra_bi
 assert_file_contains "${ROOT_DIR}/.github/workflows/preview-stack.yml" "provenance-path: blueprint/__ref__/template-provenance.json"
 assert_file_contains "${ROOT_DIR}/.github/workflows/preview-stack.yml" ".github/actions/run-pulumi"
 assert_file_contains "${ROOT_DIR}/.github/workflows/preview-stack.yml" "command: preview"
+assert_file_not_contains "${ROOT_DIR}/.github/workflows/preview-stack.yml" ".github/actions/deploy-controlplane-ui"
 assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "name: Rollout Hop"
 assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "run_canary"
 assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "workflow_actions_ref"
@@ -64,6 +76,12 @@ assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" ".github/ac
 assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "infra_binaries_repo"
 assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "provenance-path: blueprint/__ref__/template-provenance.json"
 assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" ".github/actions/run-pulumi"
+assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "controlplane_ui_pages_project"
+assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "controlplane_ui_artifact_name"
+assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "controlplane_ui_runtime_config_json"
+assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" ".github/actions/deploy-controlplane-ui"
+assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "if: \${{ inputs.controlplane_ui_pages_project != '' }}"
+assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "Materialize Control Plane UI runtime config"
 assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" ".github/actions/reconcile-project-info"
 assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "reconcile_managed_dsql_endpoint"
 assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "name: Re-apply stack after managed DSQL reconcile"


### PR DESCRIPTION
## Summary
- add a reusable `deploy-controlplane-ui` composite action that validates the named release manifest entry, unpacks the site bundle, injects deployment-provided `ltbase-controlplane.config.json`, and publishes with `wrangler pages deploy`
- extend `rollout-hop.yml` with optional control plane UI inputs so rollout can publish the UI from the unified application release while preview stays infra-only
- document the new rollout interface and cover the action/workflow wiring with regression tests

## Verification
- `bash test/generic-workflows-test.sh`
- `bash test/deploy-controlplane-ui-test.sh`

## Related
- Implements #17
