### PR TITLE
fix: use manifest-path workflow output

### DIFF
--- a/.github/workflows/rollout-hop.yml
+++ b/.github/workflows/rollout-hop.yml
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     outputs:
       release_id: ${{ steps.meta.outputs.release_id }}
-      manifest_path: ${{ steps.download.outputs.manifest_path }}
+      manifest_path: ${{ steps.download.outputs.manifest-path }}
       pulumi_stack: ${{ steps.meta.outputs.pulumi_stack }}
       deployment_outputs_json: ${{ steps.outputs.outputs.deployment_outputs_json }}
     steps:
@@ -251,7 +251,7 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.cloudflare_api_token }}
         with:
-          manifest-path: ${{ steps.download.outputs.manifest_path }}
+          manifest-path: ${{ steps.download.outputs.manifest-path }}
           runtime-config-json: ${{ inputs.controlplane_ui_runtime_config_json }}
           cloudflare-pages-project: ${{ inputs.controlplane_ui_pages_project }}
       - id: outputs

--- a/test/generic-workflows-test.sh
+++ b/test/generic-workflows-test.sh
@@ -85,6 +85,7 @@ assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "if: \${{ i
 assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" ".github/actions/reconcile-project-info"
 assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "reconcile_managed_dsql_endpoint"
 assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "name: Deploy control plane UI"
+assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "manifest-path: \${{ steps.download.outputs.manifest-path }}"
 assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "runtime-config-json: \${{ inputs.controlplane_ui_runtime_config_json }}"
 assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "cloudflare-pages-project: \${{ inputs.controlplane_ui_pages_project }}"
 assert_file_contains "${ROOT_DIR}/.github/workflows/rollout-hop.yml" "name: Re-apply stack after managed DSQL reconcile"


### PR DESCRIPTION
## Summary
- use the `manifest-path` output name exposed by `download-private-release`
- pass the downloaded manifest into the control plane UI deploy step correctly
- add regression coverage for the output name in workflow tests

## Testing
- bash test/generic-workflows-test.sh
- bash test/deploy-controlplane-ui-test.sh

## Related
- refs Lychee-Technology/ltbase-private-deployment#89