### PR TITLE
fix: preserve ui runtime config json

### DIFF
--- a/.github/actions/deploy-controlplane-ui/action.yml
+++ b/.github/actions/deploy-controlplane-ui/action.yml
@@ -29,11 +29,18 @@ runs:
   steps:
     - name: Deploy control plane UI artifact
       shell: bash
+      env:
+        INPUT_MANIFEST_PATH: ${{ inputs.manifest-path }}
+        INPUT_RUNTIME_CONFIG_JSON: ${{ inputs.runtime-config-json }}
+        INPUT_CLOUDFLARE_PAGES_PROJECT: ${{ inputs.cloudflare-pages-project }}
+        INPUT_PAGES_BRANCH: ${{ inputs.pages-branch }}
+        INPUT_ARTIFACT_NAME: ${{ inputs.artifact-name }}
+        INPUT_DEPLOY_ROOT: ${{ inputs.deploy-root }}
       run: |
         "${{ github.action_path }}/deploy.sh" \
-          --manifest-path "${{ inputs.manifest-path }}" \
-          --runtime-config-json "${{ inputs.runtime-config-json }}" \
-          --cloudflare-pages-project "${{ inputs.cloudflare-pages-project }}" \
-          --pages-branch "${{ inputs.pages-branch }}" \
-          --artifact-name "${{ inputs.artifact-name }}" \
-          --deploy-root "${{ inputs.deploy-root }}"
+          --manifest-path "${INPUT_MANIFEST_PATH}" \
+          --runtime-config-json "${INPUT_RUNTIME_CONFIG_JSON}" \
+          --cloudflare-pages-project "${INPUT_CLOUDFLARE_PAGES_PROJECT}" \
+          --pages-branch "${INPUT_PAGES_BRANCH}" \
+          --artifact-name "${INPUT_ARTIFACT_NAME}" \
+          --deploy-root "${INPUT_DEPLOY_ROOT}"

--- a/test/deploy-controlplane-ui-test.sh
+++ b/test/deploy-controlplane-ui-test.sh
@@ -142,5 +142,7 @@ assert_file_equals "${deploy_root}/ltbase-controlplane.config.json" "${runtime_c
 assert_file_contains "${ACTION_PATH}" "runtime-config-json"
 assert_file_contains "${ACTION_PATH}" "cloudflare-pages-project"
 assert_file_contains "${ACTION_PATH}" "pages-branch"
+assert_file_contains "${ACTION_PATH}" "INPUT_RUNTIME_CONFIG_JSON: \${{ inputs.runtime-config-json }}"
+assert_file_contains "${ACTION_PATH}" '--runtime-config-json "${INPUT_RUNTIME_CONFIG_JSON}"'
 
 printf 'PASS: deploy-controlplane-ui tests\n'


### PR DESCRIPTION
## Summary
- pass deploy-controlplane-ui inputs through environment variables before invoking the shell script
- preserve JSON quoting for `runtime-config-json` so the deploy script receives valid JSON
- add regression coverage for env-backed runtime config argument passing

## Testing
- bash test/deploy-controlplane-ui-test.sh
- bash test/generic-workflows-test.sh

## Related
- refs Lychee-Technology/ltbase-private-deployment#89