### PR TITLE
ci: update GitHub Actions major versions

### DIFF
--- a/.github/workflows/diagnose-go-compile.yml
+++ b/.github/workflows/diagnose-go-compile.yml
@@ -66,7 +66,7 @@ jobs:
           repository: ${{ inputs.blueprint_repository }}
           ref: ${{ inputs.blueprint_ref }}
           path: blueprint
-      - uses: aws-actions/configure-aws-credentials@v5
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ inputs.aws_region }}

--- a/.github/workflows/preview-stack.yml
+++ b/.github/workflows/preview-stack.yml
@@ -90,7 +90,7 @@ jobs:
           provenance_path: blueprint/__ref__/template-provenance.json
           working_directory: blueprint/${{ inputs.working_directory }}
           token: ${{ github.token }}
-      - uses: aws-actions/configure-aws-credentials@v5
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.aws_role_arn }}
           aws-region: ${{ inputs.aws_region }}

--- a/.github/workflows/rollout-hop.yml
+++ b/.github/workflows/rollout-hop.yml
@@ -123,7 +123,7 @@ jobs:
           provenance_path: blueprint/__ref__/template-provenance.json
           working_directory: blueprint/${{ inputs.working_directory }}
           token: ${{ github.token }}
-      - uses: aws-actions/configure-aws-credentials@v5
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.aws_role_arn }}
           aws-region: ${{ inputs.aws_region }}


### PR DESCRIPTION
## Summary
- upgrade aws-actions/configure-aws-credentials from v5 to v6 in reusable workflows
- keep workflow interfaces and inputs unchanged
- align workflow action majors across deployment automation

## Test Plan
- [x] run `git diff --check -- .github/workflows`
- [x] confirm no `aws-actions/configure-aws-credentials@v4` or `@v5` matches remain in workspace